### PR TITLE
Rewrite database access wrappers

### DIFF
--- a/dozer/cogs/general.py
+++ b/dozer/cogs/general.py
@@ -84,7 +84,7 @@ class General(Cog):
                              description=command.help or (None if command.example_usage else 'No information provided.'),
                              color=discord.Color.blue())
         usage = command.example_usage
-        if usage is not None:
+        if usage:
             info.add_field(name='Usage', value=usage.format(prefix=ctx.prefix, name=ctx.invoked_with), inline=False)
         info.set_footer(text='Dozer Help | {!r} command | Info'.format(command.qualified_name))
         await self._show_help(ctx, info, 'Subcommands: {prefix}{name} {signature}', '', '{name!r} command',
@@ -173,7 +173,7 @@ class General(Cog):
         Generates a set number of single use invites.
         """
 
-        settings = await WelcomeChannel.get_by_guild(ctx.guild.id)
+        settings = await WelcomeChannel.get_by(guild_id=ctx.guild.id)
         if len(settings) == 0:
             await ctx.send(
                 "There is no welcome channel set. Please set one using `{0}welcomeconfig channel` and try again.".format(
@@ -243,9 +243,8 @@ class WelcomeChannel(db.DatabaseTable):
         self.channel_id = channel_id
 
     @classmethod
-    async def get_by_attribute(cls, obj_id, column_name):
-        """Gets a list of all objects with a given attribute"""
-        results = await super().get_by_attribute(obj_id, column_name)
+    async def get_by(cls, **kwargs):
+        results = await super().get_by(**kwargs)
         result_list = []
         for result in results:
             obj = WelcomeChannel(guild_id=result.get("guild_id"), channel_id=result.get("channel_id"))

--- a/dozer/cogs/moderation.py
+++ b/dozer/cogs/moderation.py
@@ -52,7 +52,7 @@ class Moderation(Cog):
             await target.send(embed=modlog_embed)
         except discord.Forbidden:
             await orig_channel.send("Failed to DM modlog to user")
-        modlog_channel = await GuildModLog.get_by_guild(guild_id=actor.guild.id)
+        modlog_channel = await GuildModLog.get_by(guild_id=actor.guild.id)
         if orig_channel is not None:
             await orig_channel.send(embed=modlog_embed)
         if len(modlog_channel) != 0:
@@ -106,7 +106,7 @@ class Moderation(Cog):
 
         await asyncio.sleep(seconds)
 
-        user = await punishment.get_by_user(user_id=target.id, user_column_name="member_id")
+        user = await punishment.get_by(member_id=target.id)
         if len(user) != 0:
             await self.mod_log(actor,
                                "un" + punishment.past_participle,
@@ -118,7 +118,7 @@ class Moderation(Cog):
             self.bot.loop.create_task(coro=punishment.finished_callback(self, target))
 
         if ent:
-            await ent.delete(data_tuple_list=[("guild_id", target.guild.id), ("target_id", target.id)])
+            await PunishmentTimerRecords.delete(guild_id=target.guild.id, target_id=target.id, type_of_punishment=punishment.type)
 
     async def _check_links_warn(self, msg, role):
         """Warns a user that they can't send links."""
@@ -130,7 +130,7 @@ class Moderation(Cog):
         """Checks messages for the links role if necessary, then checks if the author is allowed to send links in the server"""
         if msg.guild is None or not isinstance(msg.author, discord.Member) or not msg.guild.me.guild_permissions.manage_messages:
             return
-        config = await self.links_config.query_one(obj_id=msg.guild.id, column_name="guild_id")
+        config = await self.links_config.query_one(guild_id=msg.guild.id)
         if config is None:
             return
         role = msg.guild.get_role(config.role_id)
@@ -152,14 +152,8 @@ class Moderation(Cog):
         actor: the acting user who requested the mute
         orig_channel: the channel of the request origin
         """
-        user = None
-        results = await Mute.get_by_guild(guild_id=member.guild.id)
-        for result in results:
-            if result.member_id == member.id:
-                user = result
-                break
-
-        if user is not None:
+        results = await Mute.get_by(guild_id=member.guild.id, member_id=member.id)
+        if results:
             return False # member already muted
         else:
             user = Mute(member_id=member.id, guild_id=member.guild.id)
@@ -172,14 +166,9 @@ class Moderation(Cog):
 
     async def _unmute(self, member: discord.Member):
         """Unmutes a user."""
-        results = await Mute.get_by_guild(guild_id=member.guild.id)
-        user = None
-        for result in results:
-            if result.member_id == member.id:
-                user = result
-                break
-        if user is not None:
-            await user.delete(data_tuple_list=[("member_id", member.id), ("guild_id", member.guild.id)])
+        results = await Mute.get_by(guild_id=member.guild.id, member_id=member.id)
+        if results:
+            await Mute.delete(member_id=member.id, guild_id=member.guild.id)
             await self.perm_override(member, send_messages=None, add_reactions=None)
             return True
         else:
@@ -195,11 +184,9 @@ class Moderation(Cog):
         actor: the acting user who requested the mute
         orig_channel: the channel of the request origin
         """
-        results = await Deafen.get_by_guild(guild_id=member.guild.id)
-        if len(results) != 0:
-            for result in results:
-                if result.member_id == member.id:
-                    return False
+        results = await Deafen.get_by(guild_id=member.guild.id, member_id=member.id)
+        if results:
+            return False
         else:
             user = Deafen(member_id=member.id, guild_id=member.guild.id, self_inflicted=self_inflicted)
             await user.update_or_add()
@@ -218,17 +205,12 @@ class Moderation(Cog):
 
     async def _undeafen(self, member: discord.Member, reason, ctx):
         """Undeafens a user."""
-        users = await Deafen.get_by_guild(guild_id=member.guild.id)
-        user = None
-        for user_to_check in users:
-            if user_to_check.member_id == member.id:
-                user = user_to_check
-                break
-        if user is not None:
+        results = await Deafen.get_by(guild_id=member.guild.id, member_id=member.id)
+        if results:
             await self.perm_override(member=member, read_messages=None)
-            await user.delete(data_tuple_list=[("member_id", member.id), ("guild_id", member.guild.id)])
+            await Deafen.delete(member_id=member.id, guild_id=member.guild.id)
             await self.mod_log(actor=ctx.author, action="undeafened", target=member, reason=reason,
-                               orig_channel=ctx.channel, embed_color=discord.Color.green(), global_modlog=not user.self_inflicted)
+                               orig_channel=ctx.channel, embed_color=discord.Color.green(), global_modlog=not results[0].self_inflicted)
         else:
             await ctx.send("Member is not deafened!")
 
@@ -237,7 +219,7 @@ class Moderation(Cog):
     @Cog.listener('on_ready')
     async def on_ready(self):
         """Restore punishment timers on bot startup"""
-        q = await PunishmentTimerRecords.get_all(PunishmentTimerRecords)
+        q = await PunishmentTimerRecords.get_by()  # no filters: all
         for r in q:
             guild = self.bot.get_guild(r.guild_id)
             actor = guild.get_member(r.actor_id)
@@ -246,7 +228,7 @@ class Moderation(Cog):
             punishment_type = r.type_of_punishment
             reason = r.reason or ""
             seconds = max(int(r.target_ts - time.time()), 0.01)
-            await r.delete(data_tuple_list=[(r.id, "id")])
+            await PunishmentTimerRecords.delete(id=r.id)
             self.bot.loop.create_task(self.punishment_timer(seconds, target, PunishmentTimerRecords.type_map[punishment_type], reason, actor,
                                                             orig_channel))
             getLogger('dozer').info(f"Restarted {PunishmentTimerRecords.type_map[punishment_type].__name__} of {target} in {guild}")
@@ -258,18 +240,16 @@ class Moderation(Cog):
         join.set_author(name='Member Joined', icon_url=member.avatar_url_as(format='png', size=32))
         join.description = "{0.mention}\n{0} ({0.id})".format(member)
         join.set_footer(text="{} | {} members".format(member.guild.name, member.guild.member_count))
-        memberlogchannel = await GuildMemberLog.get_by_guild(guild_id=member.guild.id)
+        memberlogchannel = await GuildMemberLog.get_by(guild_id=member.guild.id)
         if len(memberlogchannel) != 0:
             channel = member.guild.get_channel(memberlogchannel[0].memberlog_channel)
             await channel.send(embed=join)
-        users = await Mute.get_by_guild(guild_id=member.guild.id)
-        for user in users:
-            if user.member_id == member.id:
-                await self.perm_override(member, add_reactions=False, send_messages=False)
-        users = await Deafen.get_by_guild(guild_id=member.guild.id)
-        for user in users:
-            if user.member_id == member.id:
-                await self.perm_override(member, read_messages=False)
+        users = await Mute.get_by(guild_id=member.guild.id, member_id=member.id)
+        if users:
+            await self.perm_override(member, add_reactions=False, send_messages=False)
+        users = await Deafen.get_by(guild_id=member.guild.id, member_id=member.id)
+        if users:
+            await self.perm_override(member, read_messages=False)
 
     @Cog.listener('on_member_remove')
     async def on_member_remove(self, member):
@@ -278,7 +258,7 @@ class Moderation(Cog):
         leave.set_author(name='Member Left', icon_url=member.avatar_url_as(format='png', size=32))
         leave.description = "{0.mention}\n{0} ({0.id})".format(member)
         leave.set_footer(text="{} | {} members".format(member.guild.name, member.guild.member_count))
-        memberlogchannel = await GuildMemberLog.get_by_guild(guild_id=member.guild.id)
+        memberlogchannel = await GuildMemberLog.get_by(guild_id=member.guild.id)
         if len(memberlogchannel) != 0:
             channel = member.guild.get_channel(memberlogchannel[0].memberlog_channel)
             await channel.send(embed=leave)
@@ -291,7 +271,7 @@ class Moderation(Cog):
 
         if await self.check_links(message):
             return
-        config = await GuildNewMember.get_by_guild(guild_id=message.guild.id)
+        config = await GuildNewMember.get_by(guild_id=message.guild.id)
         if len(config) != 0:
             config = config[0]
             string = config.message
@@ -329,7 +309,7 @@ class Moderation(Cog):
                 e.add_field(name="Footer", value=i.footer)
         if message.attachments:
             e.add_field(name="Attachments", value=", ".join([i.url for i in message.attachments]))
-        messagelogchannel = await self.edit_delete_config.query_one(obj_id=message.guild.id, column_name="guild_id")
+        messagelogchannel = await self.edit_delete_config.query_one(guild_id=message.guild.id)
         if messagelogchannel is not None:
             channel = message.guild.get_channel(messagelogchannel.messagelog_channel)
             if channel is not None:
@@ -379,7 +359,7 @@ class Moderation(Cog):
                         e.add_field(name=x.name, value=x.value)
             if after.attachments:
                 e.add_field(name="Attachments", value=", ".join([i.url for i in before.attachments]))
-            messagelogchannel = await self.edit_delete_config.query_one(obj_id=before.guild.id, column_name="guild_id")
+            messagelogchannel = await self.edit_delete_config.query_one(guild_id=before.guild.id)
             if messagelogchannel is not None:
                 channel = before.guild.get_channel(messagelogchannel.messagelog_channel)
                 if channel is not None:
@@ -402,7 +382,7 @@ class Moderation(Cog):
     @bot_has_permissions(manage_roles=True)
     async def timeout(self, ctx, duration: float):
         """Set a timeout (no sending messages or adding reactions) on the current channel."""
-        settings = await MemberRole.get_by_guild(guild_id=ctx.guild.id)
+        settings = await MemberRole.get_by(guild_id=ctx.guild.id)
         if len(settings) == 0:
             settings = MemberRole(guild_id=ctx.guild.id)
             await settings.update_or_add()
@@ -597,7 +577,7 @@ class Moderation(Cog):
     @has_permissions(administrator=True)
     async def modlogconfig(self, ctx, channel_mentions: discord.TextChannel):
         """Set the modlog channel for a server by passing the channel id"""
-        config = await GuildModLog.get_by_guild(guild_id=ctx.guild.id)
+        config = await GuildModLog.get_by(guild_id=ctx.guild.id)
         if len(config) != 0:
             config = config[0]
             config.name = ctx.guild.name
@@ -614,7 +594,7 @@ class Moderation(Cog):
     @has_permissions(administrator=True)
     async def nmconfig(self, ctx, channel_mention: discord.TextChannel, role: discord.Role, *, message):
         """Sets the config for the new members channel"""
-        config = await GuildNewMember.get_by_guild(guild_id=ctx.guild.id)
+        config = await GuildNewMember.get_by(guild_id=ctx.guild.id)
         if len(config) != 0:
             config = config[0]
             config.channel_id = channel_mention.id
@@ -644,7 +624,7 @@ class Moderation(Cog):
         if member_role >= ctx.author.top_role:
             raise BadArgument('member role cannot be higher than your top role!')
 
-        settings = await MemberRole.get_by_guild(guild_id=ctx.guild.id)
+        settings = await MemberRole.get_by(guild_id=ctx.guild.id)
         if len(settings) == 0:
             settings = MemberRole(guild_id=ctx.guild.id, member_role=member_role.id)
         else:
@@ -672,7 +652,7 @@ class Moderation(Cog):
         if link_role >= ctx.author.top_role:
             raise BadArgument('Link role cannot be higher than your top role!')
 
-        settings = await GuildMessageLinks.get_by_guild(guild_id=ctx.guild.id)
+        settings = await GuildMessageLinks.get_by(guild_id=ctx.guild.id)
         if len(settings) == 0:
             settings = GuildMessageLinks(guild_id=ctx.guild.id, role_id=link_role.id)
         else:
@@ -694,7 +674,7 @@ class Moderation(Cog):
     @has_permissions(administrator=True)
     async def memberlogconfig(self, ctx, channel_mentions: discord.TextChannel):
         """Set the join/leave channel for a server by passing a channel mention"""
-        config = await GuildMemberLog.get_by_guild(guild_id=ctx.guild.id)
+        config = await GuildMemberLog.get_by(guild_id=ctx.guild.id)
         if len(config) != 0:
             config = config[0]
             config.name = ctx.guild.name
@@ -711,7 +691,7 @@ class Moderation(Cog):
     @has_permissions(administrator=True)
     async def messagelogconfig(self, ctx, channel_mentions: discord.TextChannel):
         """Set the modlog channel for a server by passing the channel id"""
-        config = await GuildMessageLog.get_by_guild(guild_id=ctx.guild.id)
+        config = await GuildMessageLog.get_by(guild_id=ctx.guild.id)
         if len(config) != 0:
             config = config[0]
             config.name = ctx.guild.name
@@ -751,9 +731,8 @@ class Mute(db.DatabaseTable):
         self.guild_id = guild_id
 
     @classmethod
-    async def get_by_attribute(cls, obj_id, column_name):
-        """Gets a list of all objects with a given attribute"""
-        results = await super().get_by_attribute(obj_id, column_name)
+    async def get_by(cls, **kwargs):
+        results = await super().get_by(**kwargs)
         result_list = []
         for result in results:
             obj = Mute(member_id=result.get("member_id"), guild_id=result.get("guild_id"))
@@ -806,9 +785,8 @@ class Deafen(db.DatabaseTable):
         self.self_inflicted = self_inflicted
 
     @classmethod
-    async def get_by_attribute(cls, obj_id, column_name):
-        """Gets a list of all objects with a given attribute"""
-        results = await super().get_by_attribute(obj_id, column_name)
+    async def get_by(cls, **kwargs):
+        results = await super().get_by(**kwargs)
         result_list = []
         for result in results:
             obj = Deafen(member_id=result.get("member_id"), guild_id=result.get("guild_id"),
@@ -840,9 +818,8 @@ class GuildModLog(db.DatabaseTable):
         self.name = name
 
     @classmethod
-    async def get_by_attribute(cls, obj_id, column_name):
-        """Gets a list of all objects with a given attribute"""
-        results = await super().get_by_attribute(obj_id, column_name)
+    async def get_by(cls, **kwargs):
+        results = await super().get_by(**kwargs)
         result_list = []
         for result in results:
             obj = GuildModLog(guild_id=result.get("guild_id"), modlog_channel=result.get("modlog_channel"),
@@ -872,9 +849,8 @@ class MemberRole(db.DatabaseTable):
         self.member_role = member_role
 
     @classmethod
-    async def get_by_attribute(cls, obj_id, column_name):
-        """Gets a list of all objects with a given attribute"""
-        results = await super().get_by_attribute(obj_id, column_name)
+    async def get_by(cls, **kwargs):
+        results = await super().get_by(**kwargs)
         result_list = []
         for result in results:
             obj = MemberRole(member_role=result.get("member_role"), guild_id=result.get("guild_id"))
@@ -907,9 +883,8 @@ class GuildNewMember(db.DatabaseTable):
         self.message = message
 
     @classmethod
-    async def get_by_attribute(cls, obj_id, column_name):
-        """Gets a list of all objects with a given attribute"""
-        results = await super().get_by_attribute(obj_id, column_name)
+    async def get_by(cls, **kwargs):
+        results = await super().get_by(**kwargs)
         result_list = []
         for result in results:
             obj = GuildNewMember(guild_id=result.get("guild_id"), channel_id=result.get("channel_id"),
@@ -941,9 +916,8 @@ class GuildMemberLog(db.DatabaseTable):
         self.name = name
 
     @classmethod
-    async def get_by_attribute(cls, obj_id, column_name):
-        """Gets a list of all objects with a given attribute"""
-        results = await super().get_by_attribute(obj_id, column_name)
+    async def get_by(cls, **kwargs):
+        results = await super().get_by(**kwargs)
         result_list = []
         for result in results:
             obj = GuildMemberLog(guild_id=result.get("guild_id"), memberlog_channel=result.get("memberlog_channel"),
@@ -975,9 +949,8 @@ class GuildMessageLog(db.DatabaseTable):
         self.messagelog_channel = messagelog_channel
 
     @classmethod
-    async def get_by_attribute(cls, obj_id, column_name):
-        """Gets a list of all objects with a given attribute"""
-        results = await super().get_by_attribute(obj_id, column_name)
+    async def get_by(cls, **kwargs):
+        results = await super().get_by(**kwargs)
         result_list = []
         for result in results:
             obj = GuildMessageLog(guild_id=result.get("guild_id"), name=result.get("name"),
@@ -1007,9 +980,8 @@ class GuildMessageLinks(db.DatabaseTable):
         self.role_id = role_id
 
     @classmethod
-    async def get_by_attribute(cls, obj_id, column_name):
-        """Gets a list of all objects with a given attribute"""
-        results = await super().get_by_attribute(obj_id, column_name)
+    async def get_by(cls, **kwargs):
+        results = await super().get_by(**kwargs)
         result_list = []
         for result in results:
             obj = GuildMessageLinks(guild_id=result.get("guild_id"), role_id=result.get("role_id"))
@@ -1051,9 +1023,8 @@ class PunishmentTimerRecords(db.DatabaseTable):
         self.reason = reason
 
     @classmethod
-    async def get_by_attribute(cls, obj_id, column_name):
-        """Gets a list of all objects with a given attribute"""
-        results = await super().get_by_attribute(obj_id, column_name)
+    async def get_by(cls, **kwargs):
+        results = await super().get_by(**kwargs)
         result_list = []
         for result in results:
             obj = PunishmentTimerRecords(guild_id=result.get("guild_id"), actor_id=result.get("actor_id"),
@@ -1064,22 +1035,6 @@ class PunishmentTimerRecords(db.DatabaseTable):
                                          input_id=result.get('id'))
             result_list.append(obj)
         return result_list
-
-    async def get_all(self):
-        async with db.Pool.acquire() as conn:  # Use transaction here?
-            results = await conn.fetch(f"""SELECT * FROM {self.__tablename__}""")
-            result_list = []
-            for result in results:
-                obj = PunishmentTimerRecords(guild_id=result.get("guild_id"), actor_id=result.get("actor_id"),
-                                             target_id=result.get("target_id"),
-                                             type_of_punishment=result.get("type_of_punishment"),
-                                             target_ts=result.get("target_ts"),
-                                             orig_channel_id=result.get("orig_channel_id"), reason=result.get("reason"),
-                                             input_id=result.get('id'))
-                # for var in obj.__dict__:
-                #     setattr(obj, var, result.get(var))
-                result_list.append(obj)
-            return result_list
 
 
 def setup(bot):

--- a/dozer/cogs/moderation.py
+++ b/dozer/cogs/moderation.py
@@ -887,9 +887,6 @@ class MemberRole(db.DatabaseTable):
             ON CONFLICT (guild_id) DO UPDATE
             SET member_role = excluded.member_role;
             """
-            print(statement)
-            for value in values:
-                print(value, type(value))
             await conn.execute(statement, *values)
 
 

--- a/dozer/cogs/roles.py
+++ b/dozer/cogs/roles.py
@@ -28,11 +28,7 @@ class Roles(Cog):
         """Restores a member's roles when they join if they have joined before."""
         me = member.guild.me
         top_restorable = me.top_role.position if me.guild_permissions.manage_roles else 0
-        restoreables = (await MissingRole.get_by_guild(guild_id=member.guild.id))
-        restore = []
-        for restorable in restoreables:
-            if restorable.member_id == member.id:
-                restore.append(restorable)
+        restore = await MissingRole.get_by(guild_id=member.guild.id, member_id=member.id)
         if len(restore) == 0:
             return  # New member - nothing to restore
 
@@ -46,8 +42,7 @@ class Roles(Cog):
             else:
                 valid.add(role)
         for entry in restore:
-            await MissingRole.delete(data_tuple_list=[("role_id", entry.role_id),
-                                                      ("member_id", entry.member_id)])  # Not missing anymore - remove the record to free up the primary key
+            await MissingRole.delete(role_id=entry.role_id, member_id=entry.member_id)  # Not missing anymore - remove the record to free up the primary key
 
         await member.add_roles(*valid)
         if not missing and not cant_give:
@@ -76,20 +71,20 @@ class Roles(Cog):
         guild_id = member.guild.id
         member_id = member.id
         for role in member.roles[1:]:  # Exclude the @everyone role
-            db_member = MissingRole(role_id=role.id, role_name=f"'{role.name}'", guild_id=guild_id, member_id=member_id)
+            db_member = MissingRole(role_id=role.id, role_name=role.name, guild_id=guild_id, member_id=member_id)
             await db_member.update_or_add()
 
     async def giveme_purge(self, rolelist):
-        """Purges roles in the giveme database that no longer exist"""
+        """Purges roles in the giveme database that no longer exist. The argument is a list of GiveableRole objects."""
         for role in rolelist:
-            dbrole = await GiveableRole.get_by_role(role_id=role.role_id)
-            if dbrole is not None:
-                await GiveableRole.delete(data_tuple_list=[("role_id", role.role_id)])
+            dbrole = await GiveableRole.get_by(role_id=role.role_id)
+            if dbrole:
+                await GiveableRole.delete(role_id=role.role_id)
 
     async def ctx_purge(self, ctx):
         """Purges all giveme roles that no longer exist in a guild"""
         counter = 0
-        roles = await GiveableRole.get_by_guild(guild_id=ctx.guild.id)
+        roles = await GiveableRole.get_by(guild_id=ctx.guild.id)
         guildroles = []
         rolelist = []
         for i in ctx.guild.roles:
@@ -111,7 +106,7 @@ class Roles(Cog):
     async def giveme(self, ctx, *, roles):
         """Give you one or more giveable roles, separated by commas."""
         norm_names = [self.normalize(name) for name in roles.split(',')]
-        giveable_ids = [tup.role_id for tup in await GiveableRole.get_by_guild(guild_id=ctx.guild.id) if tup.norm_name in norm_names]
+        giveable_ids = [tup.role_id for tup in await GiveableRole.get_by(guild_id=ctx.guild.id) if tup.norm_name in norm_names]
         valid = set(role for role in ctx.guild.roles if role.id in giveable_ids)
 
         already_have = valid & set(ctx.author.roles)
@@ -155,8 +150,8 @@ class Roles(Cog):
         if ',' in name:
             raise BadArgument('giveable role names must not contain commas!')
         norm_name = self.normalize(name)
-        settings = await GiveableRole.get_by_guild(guild_id=ctx.guild.id)
-        if norm_name in (giveable.norm_name for giveable in settings):
+        settings = await GiveableRole.get_by(guild_id=ctx.guild.id, norm_name=norm_name)
+        if settings:
             raise BadArgument('that role already exists and is giveable!')
         candidates = [role for role in ctx.guild.roles if self.normalize(role.name) == norm_name]
 
@@ -184,9 +179,8 @@ class Roles(Cog):
         if ',' in name:
             raise BadArgument('giveable role names must not contain commas!')
         norm_name = self.normalize(name)
-        settings = await GiveableRole.get_by_guild(guild_id=ctx.guild.id)
-        role = [role for role in settings if role.name == name]
-        if len(role) == 0:
+        settings = await GiveableRole.get_by(guild_id=ctx.guild.id, norm_name=norm_name)
+        if not settings:
             role = await ctx.guild.create_role(name=name, reason='Giveable role created by {}'.format(ctx.author))
             settings = GiveableRole.from_role(role)
             await settings.update_or_add()
@@ -206,7 +200,7 @@ class Roles(Cog):
     async def remove(self, ctx, *, roles):
         """Removes multiple giveable roles from you. Names must be separated by commas."""
         norm_names = [self.normalize(name) for name in roles.split(',')]
-        query = await GiveableRole.get_by_guild(ctx.guild.id)
+        query = await GiveableRole.get_by(guild_id=ctx.guild.id)
         roles_to_remove = []
         for role in query:
             if role.norm_name in norm_names:
@@ -247,10 +241,10 @@ class Roles(Cog):
             raise BadArgument('this command only works with single roles!')
         norm_name = self.normalize(name)
         valid_ids = set(role.id for role in ctx.guild.roles)
-        roles = await GiveableRole.get_by_guild(ctx.guild.id)
+        roles = await GiveableRole.get_by(guild_id=ctx.guild.id, norm_name=norm_name)
         valid_roles = []
         for role_option in roles:
-            if role_option.norm_name == norm_name and role_option.role_id in valid_ids:
+            if role_option.role_id in valid_ids:
                 valid_roles.append(role_option)
         if len(valid_roles) == 0:
             raise BadArgument('that role does not exist or is not giveable!')
@@ -258,7 +252,7 @@ class Roles(Cog):
             raise BadArgument('multiple giveable roles with that name exist!')
         else:
             role = ctx.guild.get_role(valid_roles[0].role_id)
-            await GiveableRole.delete(data_tuple_list=[("norm_name", f"'{valid_roles[0].norm_name}'")])
+            await GiveableRole.delete(guild_id=ctx.guild.id, norm_name=valid_roles[0].norm_name)
             await role.delete(reason='Giveable role deleted by {}'.format(ctx.author))
             await ctx.send('Role "{0}" deleted!'.format(role))
 
@@ -271,7 +265,7 @@ class Roles(Cog):
     @bot_has_permissions(manage_roles=True)
     async def list_roles(self, ctx):
         """Lists all giveable roles for this server."""
-        names = [tup.norm_name for tup in await GiveableRole.get_by_guild(ctx.guild.id)]
+        names = [tup.name for tup in await GiveableRole.get_by(guild_id=ctx.guild.id)]
         e = discord.Embed(title='Roles available to self-assign', color=discord.Color.blue())
         e.description = '\n'.join(sorted(names, key=str.casefold))
         await ctx.send(embed=e)
@@ -295,7 +289,7 @@ class Roles(Cog):
             raise BadArgument('this command only works with single roles!')
         norm_name = self.normalize(name)
         valid_ids = set(role.id for role in ctx.guild.roles)
-        roles = await GiveableRole.get_by_guild(ctx.guild.id)
+        roles = await GiveableRole.get_by(guild_id=ctx.guild.id)
         valid_roles = []
         for role_option in roles:
             if role_option.norm_name == norm_name and role_option.role_id in valid_ids:
@@ -305,7 +299,7 @@ class Roles(Cog):
         elif len(valid_roles) > 1:
             raise BadArgument('multiple giveable roles with that name exist!')
         else:
-            await GiveableRole.delete(data_tuple_list=[("norm_name", f"'{valid_roles[0].norm_name}'")])
+            await GiveableRole.delete(guild_id=ctx.guild.id, norm_name=valid_roles[0].norm_name)
             await ctx.send('Role "{0}" deleted from list!'.format(name))
 
     delete.example_usage = """
@@ -372,20 +366,19 @@ class GiveableRole(db.DatabaseTable):
         self.norm_name = norm_name
 
     @classmethod
-    async def get_by_attribute(cls, obj_id, column_name):
-        """Gets a list of all objects with a given attribute"""
-        results = await super().get_by_attribute(obj_id, column_name)
+    async def get_by(cls, **kwargs):
+        results = await super().get_by(**kwargs)
         result_list = []
         for result in results:
             obj = GiveableRole(guild_id=result.get("guild_id"), role_id=result.get("role_id"),
-                               name=result.get('role_name'), norm_name=result.get("norm_name"))
+                               name=result.get("name"), norm_name=result.get("norm_name"))
             result_list.append(obj)
         return result_list
 
     @classmethod
     def from_role(cls, role):
         """Creates a GiveableRole record from a discord.Role."""
-        return cls(role_id=role.id, name=f"'{role.name}'", norm_name=f"'{Roles.normalize(role.name)}'", guild_id=role.guild.id)
+        return cls(role_id=role.id, name=role.name, norm_name=Roles.normalize(role.name), guild_id=role.guild.id)
 
 
 class MissingRole(db.DatabaseTable):
@@ -414,9 +407,8 @@ class MissingRole(db.DatabaseTable):
         self.role_name = role_name
 
     @classmethod
-    async def get_by_attribute(cls, obj_id, column_name):
-        """Gets a list of all objects with a given attribute"""
-        results = await super().get_by_attribute(obj_id, column_name)
+    async def get_by(cls, **kwargs):
+        results = await super().get_by(**kwargs)
         result_list = []
         for result in results:
             obj = MissingRole(guild_id=result.get("guild_id"), role_id=result.get("role_id"),

--- a/dozer/cogs/teams.py
+++ b/dozer/cogs/teams.py
@@ -139,23 +139,6 @@ class TeamNumbers(db.DatabaseTable):
         self.team_number = team_number
         self.team_type = team_type
 
-    async def update_or_add(self):
-        """Assign the attribute to this object, then call this method to either insert the object if it doesn't exist in
-        the DB or update it if it does exist. It will update every column not specified in __uniques__."""
-        keys = []
-        values = []
-        for var, value in self.__dict__.items():
-            # Done so that the two are guaranteed to be in the same order, which isn't true of keys() and values()
-            keys.append(var)
-            values.append(str(value))
-        async with db.Pool.acquire() as conn:
-            statement = f"""
-                INSERT INTO {self.__tablename__} ({", ".join(keys)})
-                VALUES({", ".join(values)}) 
-                """
-            print(statement)
-            await conn.execute(statement)
-
     @classmethod
     async def get_by_attribute(cls, obj_id, column_name):
         """Gets a list of all objects with a given attribute"""

--- a/dozer/cogs/teams.py
+++ b/dozer/cogs/teams.py
@@ -14,8 +14,8 @@ class Teams(Cog):
     async def setteam(self, ctx, team_type, team_number: int):
         """Sets an association with your team in the database."""
         team_type = team_type.casefold()
-        dbcheck = await TeamNumbers.get_by_user(user_id=ctx.author.id)
-        if len(dbcheck) == 0 or (dbcheck[0].team_number != team_number and dbcheck[0].team_type != team_type):
+        dbcheck = await TeamNumbers.get_by(user_id=ctx.author.id, team_type=team_type, team_number=team_number)
+        if not dbcheck:
             await TeamNumbers(user_id=ctx.author.id, team_number=team_number, team_type=team_type).update_or_add()
             await ctx.send("Team number set!")
         else:
@@ -29,13 +29,11 @@ class Teams(Cog):
     async def removeteam(self, ctx, team_type, team_number: int):
         """Removes an association with a team in the database."""
         team_type = team_type.casefold()
-        results = await TeamNumbers.get_by_user(user_id=ctx.author.id)
-        removed = False
+        results = await TeamNumbers.get_by(user_id=ctx.author.id, team_type=team_type, team_number=team_number)
         if len(results) != 0:
-            await TeamNumbers.delete([("team_number", team_number), ("team_type", team_type)])
+            await TeamNumbers.delete(user_id=ctx.author.id, team_number=team_number, team_type=team_type)
             await ctx.send("Removed association with {} team {}".format(team_type, team_number))
-            removed = True
-        if not removed:
+        else:
             await ctx.send("Couldn't find any associations with that team!")
 
     removeteam.example_usage = """
@@ -48,7 +46,7 @@ class Teams(Cog):
         """Allows you to see the teams for the mentioned user. If no user is mentioned, your teams are displayed."""
         if user is None:
             user = ctx.author
-        teams = await TeamNumbers.get_by_user(user_id=user.id)
+        teams = await TeamNumbers.get_by(user_id=user.id)
         if len(teams) == 0:
             raise BadArgument("Couldn't find any team associations for that user!")
         else:
@@ -68,10 +66,7 @@ class Teams(Cog):
     async def onteam(self, ctx, team_type, team_number: int):
         """Allows you to see who has associated themselves with a particular team."""
         team_type = team_type.casefold()
-        users = await TeamNumbers.get_by_attribute(obj_id=team_number, column_name="team_number")
-        for user in users:
-            if user.team_type != team_type:
-                users.remove(user)
+        users = await TeamNumbers.get_by(team_type=team_type, team_number=team_number)
         if len(users) == 0:
             await ctx.send("Nobody on that team found!")
         else:
@@ -93,7 +88,7 @@ class Teams(Cog):
     async def top(self, ctx):
         """Show the top 10 teams by number of members in this guild."""
         users = [mem.id for mem in ctx.guild.members]
-        counts = await TeamNumbers.top10(TeamNumbers, users)
+        counts = await TeamNumbers.top10(users)
         embed = discord.Embed(title=f'Top teams in {ctx.guild.name}', color=discord.Color.blue())
         embed.description = '\n'.join(
             f'{type_.upper()} team {num} ({count} member{"s" if count > 1 else ""})' for (type_, num, count) in counts)
@@ -107,7 +102,7 @@ class Teams(Cog):
     async def on_member_join(self, member):
         """Adds a user's team association to their name when they join (if exactly 1 association)"""
         if member.guild.me.guild_permissions.manage_nicknames:
-            query = await TeamNumbers.get_by_user(user_id=member.id)
+            query = await TeamNumbers.get_by(user_id=member.id)
             if len(query) == 1:
                 nick = "{} {}{}".format(member.display_name, query[0].team_type, query[0].team_number)
                 if len(nick) <= 32:
@@ -156,9 +151,8 @@ class TeamNumbers(db.DatabaseTable):
             await conn.execute(statement, *values)
 
     @classmethod
-    async def get_by_attribute(cls, obj_id, column_name):
-        """Gets a list of all objects with a given attribute"""
-        results = await super().get_by_attribute(obj_id, column_name)
+    async def get_by(cls, **kwargs):
+        results = await super().get_by(**kwargs)
         result_list = []
         for result in results:
             obj = TeamNumbers(user_id=result.get("user_id"),
@@ -167,10 +161,11 @@ class TeamNumbers(db.DatabaseTable):
             result_list.append(obj)
         return result_list
 
-    async def top10(self, user_ids):
+    @classmethod
+    async def top10(cls, user_ids):
         """Returns the top 10 team entries"""
-        query = """SELECT team_type, team_number, count(*)
-                FROM team_numbers
+        query = f"""SELECT team_type, team_number, count(*)
+                FROM {cls.__tablename__}
                 WHERE user_id = ANY($1) --first param: list of user IDs
                 GROUP BY team_type, team_number
                 ORDER BY count DESC, team_type, team_number

--- a/dozer/cogs/voice.py
+++ b/dozer/cogs/voice.py
@@ -18,13 +18,13 @@ class Voice(Cog):
             # before and after are voice states
             if after.channel is not None:
                 # join event, give role
-                config = await Voicebinds.get_by_channel(after.channel.id)
+                config = await Voicebinds.get_by(channel_id=after.channel.id)
                 if len(config) != 0:
                     await member.add_roles(member.guild.get_role(config[0].role_id))
 
             if before.channel is not None:
                 # leave event, take role
-                config = await Voicebinds.get_by_channel(before.channel.id)
+                config = await Voicebinds.get_by(channel_id=before.channel.id)
                 if len(config) != 0:
                     await member.remove_roles(member.guild.get_role(config[0].role_id))
 
@@ -34,12 +34,12 @@ class Voice(Cog):
     async def voicebind(self, ctx, voice_channel: discord.VoiceChannel, *, role: discord.Role):
         """Associates a voice channel with a role, so users joining a voice channel will automatically be given a specified role or roles."""
 
-        config = await Voicebinds.get_by_channel(channel_id=voice_channel.id)
+        config = await Voicebinds.get_by(channel_id=voice_channel.id)
         if len(config) != 0:
             config[0].guild_id = ctx.guild.id
             config[0].channel_id = voice_channel.id
             config[0].role_id = role.id
-            config[0].update_or_add()
+            await config[0].update_or_add()
         else:
             await Voicebinds(channel_id=voice_channel.id, role_id=role.id, guild_id=ctx.guild.id).update_or_add()
 
@@ -55,10 +55,10 @@ class Voice(Cog):
     @has_permissions(manage_roles=True)
     async def voiceunbind(self, ctx, voice_channel: discord.VoiceChannel):
         """Dissasociates a voice channel with a role previously binded with the voicebind command."""
-        config = await Voicebinds.get_by_channel(voice_channel.id)
+        config = await Voicebinds.get_by(channel_id=voice_channel.id)
         if len(config) != 0:
             role = ctx.guild.get_role(config[0].role_id)
-            await config[0].delete(data_tuple_list=[('id', config[0].id)])
+            await Voicebinds.delete(id=config[0].id)
             await ctx.send(
                 "Role `{role}` will no longer be given to users in voice channel `{voice_channel}`!".format(
                     role=role, voice_channel=voice_channel))
@@ -75,7 +75,7 @@ class Voice(Cog):
     async def voicebindlist(self, ctx):
         """Lists all the voice channel to role bindings for the current server"""
         embed = discord.Embed(title="List of voice bindings for \"{}\"".format(ctx.guild), color=discord.Color.blue())
-        for config in await Voicebinds.get_by_guild(ctx.guild.id):
+        for config in await Voicebinds.get_by(guild_id=ctx.guild.id):
             channel = discord.utils.get(ctx.guild.voice_channels, id=config.channel_id)
             role = ctx.guild.get_role(config.role_id)
             embed.add_field(name=channel, value="`{}`".format(role))
@@ -113,9 +113,8 @@ class Voicebinds(db.DatabaseTable):
         self.role_id = role_id
 
     @classmethod
-    async def get_by_attribute(cls, obj_id, column_name):
-        """Gets a list of all objects with a given attribute"""
-        results = await super().get_by_attribute(obj_id, column_name)
+    async def get_by(cls, **kwargs):
+        results = await super().get_by(**kwargs)
         result_list = []
         for result in results:
             obj = Voicebinds(row_id=result.get("id"),

--- a/dozer/db.py
+++ b/dozer/db.py
@@ -143,7 +143,6 @@ class DatabaseTable:
             DELETE FROM  {cls.__tablename__}
             WHERE {data_column} = $1;
             """
-            print(statement)
             await conn.execute(statement, data)
 
     @classmethod
@@ -154,7 +153,6 @@ class DatabaseTable:
             DELETE FROM  {cls.__tablename__}
             WHERE {data_column} = $1 AND {data_column_two} = $2;
             """
-            print(statement)
             await conn.execute(statement, data, data_two)
 
 

--- a/dozer/db.py
+++ b/dozer/db.py
@@ -77,7 +77,7 @@ class DatabaseTable:
         async with Pool.acquire() as conn:
             statement = f"""
             INSERT INTO {self.__tablename__} ({", ".join(keys)})
-            VALUES({','.join(f'${i+1}' for i in range(len(values)))}) 
+            VALUES({','.join(f'${i+1}' for i in range(len(values)))})
             ON CONFLICT ({self.__uniques__}) DO UPDATE
             SET {updates}
             """
@@ -100,7 +100,7 @@ class DatabaseTable:
         """Gets a list of all objects with a given attribute. This will grab all attributes, it's more efficient to
         write your own SQL queries than use this one, but for a simple query this is fine."""
         async with Pool.acquire() as conn:  # Use transaction here?
-            stmt = await conn.fetch(f"""SELECT * FROM {cls.__tablename__} WHERE $1 = $2""", column_name, obj_id)
+            stmt = await conn.fetch(f"""SELECT * FROM {cls.__tablename__} WHERE {column_name} = $1""", obj_id)
             return stmt
 
     @classmethod
@@ -141,10 +141,10 @@ class DatabaseTable:
         async with Pool.acquire() as conn:
             statement = f"""
             DELETE FROM  {cls.__tablename__}
-            WHERE {data_column} = {data};
+            WHERE {data_column} = $1;
             """
             print(statement)
-            await conn.execute(statement)
+            await conn.execute(statement, data)
 
     @classmethod
     async def dual_criteria_delete(cls, data_column, data, data_column_two, data_two):
@@ -152,10 +152,10 @@ class DatabaseTable:
         async with Pool.acquire() as conn:
             statement = f"""
             DELETE FROM  {cls.__tablename__}
-            WHERE {data_column} = {data} AND {data_column_two} = {data_two};
+            WHERE {data_column} = $1 AND {data_column_two} = $2;
             """
             print(statement)
-            await conn.execute(statement)
+            await conn.execute(statement, data, data_two)
 
 
 class ConfigCache:

--- a/dozer/db.py
+++ b/dozer/db.py
@@ -91,60 +91,42 @@ class DatabaseTable:
                 values += ", "
                 first = False
             values += f"{key}: {value}"
-        return f"{self.__tablename__}: < {', '.join(self.__dict__.items())}>"
+        return f"{self.__tablename__}: <{values}>"
 
     # Class Methods
 
     @classmethod
-    async def get_by_attribute(cls, obj_id, column_name):
-        """Gets a list of all objects with a given attribute. This will grab all attributes, it's more efficient to
-        write your own SQL queries than use this one, but for a simple query this is fine."""
-        async with Pool.acquire() as conn:  # Use transaction here?
-            stmt = await conn.fetch(f"""SELECT * FROM {cls.__tablename__} WHERE {column_name} = $1""", obj_id)
-            return stmt
-
-    @classmethod
-    async def get_by_id(cls, obj_id):
-        """Get an instance of this object by it's primary key, id. This function will work for most subclasses using
-        `id` as it's primary key."""
-        await cls.get_by_attribute(obj_id, "id")
-
-    @classmethod
-    async def get_by_guild(cls, guild_id, guild_column_name="guild_id"):
-        """Get by guild ID"""
-        return await cls.get_by_attribute(obj_id=guild_id, column_name=guild_column_name)
-
-    @classmethod
-    async def get_by_channel(cls, channel_id, channel_column_name="channel_id"):
-        """Get by channel ID"""
-        return await cls.get_by_attribute(obj_id=channel_id, column_name=channel_column_name)
-
-    @classmethod
-    async def get_by_user(cls, user_id, user_column_name="user_id"):
-        """Get by user ID"""
-        return await cls.get_by_attribute(obj_id=user_id, column_name=user_column_name)
-
-    @classmethod
-    async def get_by_role(cls, role_id, role_column_name="role_id"):
-        """Get by role ID"""
-        return await cls.get_by_attribute(obj_id=role_id, column_name=role_column_name)
-
-    @classmethod
-    async def get_all(cls):
-        """Obtain all the things"""
-        async with Pool.acquire() as conn:  # Use transaction here?
-            return await conn.fetch(f"""SELECT * FROM {cls.__tablename__};""")
-
-    @classmethod
-    async def delete(cls, data_tuple_list):
-        """Deletes by any number of criteria specified as a list of (data_column, data) tuples"""
+    async def get_by(cls, **filters):
+        """Get a list of all records matching the given column=value criteria. This will grab all attributes, it's more
+        efficent to write your own SQL queries than use this one, but for a simple query this is fine."""
         async with Pool.acquire() as conn:
+            statement = f"SELECT * FROM {cls.__tablename__}"
+            if filters:
+                # note: this code relies on subsequent iterations of the same dict having the same iteration order.
+                # This is an implementation detail of CPython 3.6 and a language guarantee in Python 3.7+.
+                conditions = " AND ".join(f"{column_name} = ${i + 1}" for (i, column_name) in enumerate(filters))
+                statement = f"{statement} WHERE {conditions};"
+            else:
+                statement += ";"
+            return await conn.fetch(statement, *filters.values())
 
-            if len(data_tuple_list) > 1:
-                conditions = " AND ".join(f"{column_name} = ${i + 1}" for (i, (column_name, _)) in enumerate(data_tuple_list))
-            statement = f"DELETE FROM {cls.__tablename__} WHERE {conditions};"
-            params = [value for (key, value) in data_tuple_list]
-            await conn.execute(statement, *params)
+    @classmethod
+    async def delete(cls, **filters):
+        """Deletes by any number of criteria specified as column=value keyword arguments."""
+        async with Pool.acquire() as conn:
+            if filters:
+                # This code relies on properties of dicts - see get_by
+                conditions = " AND ".join(f"{column_name} = ${i + 1}" for (i, column_name) in enumerate(filters))
+                statement = f"DELETE FROM {cls.__tablename__} WHERE {conditions};"
+            else:
+                # Should this be a warning/error? It's almost certainly not intentional
+                statement = f"TRUNCATE {cls.__tablename__};"
+            await conn.execute(statement, *filters.values())
+
+    @classmethod
+    async def set_initial_version(cls):
+        """Sets initial version"""
+        await Pool.execute("""INSERT INTO versions (table_name, version_num) VALUES ($1,$2)""", cls.__tablename__, 0)
 
 
 class ConfigCache:
@@ -159,22 +141,22 @@ class ConfigCache:
         # sort the keys to make this repeatable; this allows consistency even when insertion order is different
         return tuple((k, dic[k]) for k in sorted(dic))
 
-    async def query_one(self, *args, obj_id, column_name):
+    async def query_one(self, **kwargs):
         """Query the cache for an entry matching the kwargs, then try again using the database."""
-        query_hash = args
+        query_hash = self._hash_dict(kwargs)
         if query_hash not in self.cache:
-            self.cache[query_hash] = await self.table.get_by_attribute(obj_id=obj_id, column_name=column_name)
+            self.cache[query_hash] = await self.table.get_by(**kwargs)
             if len(self.cache[query_hash]) == 0:
                 self.cache[query_hash] = None
             else:
                 self.cache[query_hash] = self.cache[query_hash][0]
             return self.cache[query_hash]
 
-    async def query_all(self, *args):
+    async def query_all(self, **kwargs):
         """Query the cache for all entries matching the kwargs, then try again using the database."""
-        query_hash = args
+        query_hash = self._hash_dict(kwargs)
         if query_hash not in self.cache:
-            self.cache[query_hash] = await self.table.get_all()
+            self.cache[query_hash] = await self.table.get_by(**kwargs)
         return self.cache[query_hash]
 
     def invalidate_entry(self, **kwargs):
@@ -182,11 +164,6 @@ class ConfigCache:
         query_hash = self._hash_dict(kwargs)
         if query_hash in self.cache:
             del self.cache[query_hash]
-
-    @classmethod
-    async def set_initial_version(cls):
-        """Sets initial version"""
-        await Pool.execute("""INSERT INTO versions (table_name, version_num) VALUES ($1,$2)""", cls.__tablename__, 0)
 
     __versions__ = {}
 


### PR DESCRIPTION
This PR replaces constructs like
```py
records = await SomeTable.get_by_guild(some_guild_id)
relevant_records = [record for record in records if record.some_other_column == criteria]
```
with
```py
relevant_records = await SomeTable.get_by(guild_id=some_guild_id, some_other_column=criteria)
```
The same change is applied to the `delete` method as well.

In addition, all of the edited cogs are tested and working with these edits. :tada: